### PR TITLE
Clean up Readme by removing member list and link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,17 +1,1 @@
-Arban, Jhave P. <br>
-Vince Justine Navarro <br>
-Janelle Jagunap <br>
-Canilo Diover Vincent <br>
-Rajan Gedoria <br>
-Guillermo II O. Trespeces <br>
-Ziggy T. Ovejera <br>
-Mary Angeline B. Nono <br>
-Vince Gian Onte <br>
-Faye Cardeno <br>
-John Kyle B. Obedoza <br>
-Sean Ethan G. Go <br>
-Realon Romnick <br>
-Jhave P. Arban <br>
-
-Join our teams channel: https://teams.microsoft.com/l/channel/19%3Aa119c3b9b5bc4ba08f3a147c41ff30ec%40thread.tacv2/BSCS251A?groupId=d43f4421-eaea-4f84-b2d0-b869a915d337&tenantId=1d981f77-3ca3-46ae-b0d4-e8044e6c7f84
 


### PR DESCRIPTION
Removed team member names and Teams channel link from Readme.