### PR TITLE
Add Nono's Encapsulation Lab completion entry

### DIFF
--- a/team-changelog.md
+++ b/team-changelog.md
@@ -4,8 +4,8 @@ Malig,, Rich Matthew 2025-1027707 03/13/2026 Encapsulation Lab Completed! \
 Onte, Vince Gian D. 2025-1021082 03/13/2026 Encapsulation Lab Completed! \
 Malig, Rich Matthew 2025-1027707 03/13/2026 Encapsulation Lab Completed! \
 Navarro, Vince Justine 2025-1029521 03/13/2026 Encapsulation Lab Completed! \
-Jagunap, Janelle 2025-1029521 03/15/2026 Encapsulation Lab Completed! 
-Nono, Mary Angeline 2025-1022691 03/15/2026 Encapsulation Lab Completed! \
+Jagunap, Janelle 2025-1029521 03/15/2026 Encapsulation Lab Completed! \
+Nono, Mary Angeline 2025-1022691 03/15/2026 Encapsulation Lab Completed! 
 
 ## Date : 03/11/2026 | Activity : Classes and Objects Lab
 Ablis, Margreleigne M. 2025-1020011 03/11/2026 Classes and Objects Lab Completed! \


### PR DESCRIPTION
Added entry for Mary Angeline Nono's Encapsulation Lab completion.
Proof of work:
SellerEncap:
<img width="555" height="897" alt="Screenshot 2026-03-15 170020" src="https://github.com/user-attachments/assets/e2811c3f-7574-4464-8f25-c0eba829f61f" />
Main_Nono:
<img width="381" height="848" alt="Screenshot 2026-03-15 165553" src="https://github.com/user-attachments/assets/bb93aa97-c1c4-4488-8d8a-e7ae795f8c0b" />
